### PR TITLE
MongoDB 게시글 연동

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -3,6 +3,7 @@ const express = require("express");
 const path = require("path");
 const cookieParser = require("cookie-parser");
 const logger = require("morgan");
+const mongoose = require("mongoose");
 
 const indexRouter = require("./routes/index");
 const adminRouter = require("./routes/admin");
@@ -53,5 +54,11 @@ app.use(function (err, req, res, next) {
     res.status(err.status || 500);
     res.render("error");
 });
+
+// CONNECT TO MONGODB SERVER
+// 임시 테스트 서버
+mongoose.connect('mongodb://34.64.200.167/plus', { useNewUrlParser: true, useUnifiedTopology: true })
+    .then(() => console.log('Successfully connected to mongodb'))
+    .catch(e => console.error(e));
 
 module.exports = app;

--- a/backend/app.js
+++ b/backend/app.js
@@ -3,7 +3,6 @@ const express = require("express");
 const path = require("path");
 const cookieParser = require("cookie-parser");
 const logger = require("morgan");
-const mongoose = require("mongoose");
 
 const indexRouter = require("./routes/index");
 const adminRouter = require("./routes/admin");
@@ -54,11 +53,5 @@ app.use(function (err, req, res, next) {
     res.status(err.status || 500);
     res.render("error");
 });
-
-// CONNECT TO MONGODB SERVER
-// 임시 테스트 서버
-mongoose.connect('mongodb://34.64.200.167/plus', { useNewUrlParser: true, useUnifiedTopology: true })
-    .then(() => console.log('Successfully connected to mongodb'))
-    .catch(e => console.error(e));
 
 module.exports = app;

--- a/backend/models/post.js
+++ b/backend/models/post.js
@@ -1,0 +1,44 @@
+const mongoose = require('mongoose');
+
+// 임시 게시글 스키마 구조
+const postSchema = new mongoose.Schema({
+    title: {
+        type: String,
+        required: true,
+    },
+    content: {
+        type: String,
+        required: true,
+    },
+},{
+    collection: 'post',
+},);
+
+// 모델 추가
+postSchema.statics.create = function (payload) {
+    const post = new this(payload);
+
+    return post.save();
+}
+
+// 모델 전체 검색
+postSchema.statics.findAll = function () {
+    return this.find({});
+}
+
+// 게시글id로 검색
+postSchema.statics.findOneByPostid = function (_id) {
+    return this.find({ _id });
+}
+
+// 게시글 id를 통해 업데이트
+postSchema.statics.updateByPostid = function (_id, payload) {
+    return this.findOneAndUpdate({ _id }, payload, { new: true });
+}
+
+// 게시글 id를 통해 삭제
+postSchema.statics.deleteByPostid = function (_id) {
+    return this.remove({ _id });
+}
+
+module.exports = mongoose.model('Post', postSchema);

--- a/backend/models/post.js
+++ b/backend/models/post.js
@@ -1,44 +1,18 @@
 const mongoose = require('mongoose');
+const mongoconnection = require('../lib/mongo_config');
 
 // 임시 게시글 스키마 구조
 const postSchema = new mongoose.Schema({
-    title: {
-        type: String,
+    post_id: {
+        type: Number,
         required: true,
     },
-    content: {
+    contents: {
         type: String,
         required: true,
     },
 },{
     collection: 'post',
 },);
-
-// 모델 추가
-postSchema.statics.create = function (payload) {
-    const post = new this(payload);
-
-    return post.save();
-}
-
-// 모델 전체 검색
-postSchema.statics.findAll = function () {
-    return this.find({});
-}
-
-// 게시글id로 검색
-postSchema.statics.findOneByPostid = function (_id) {
-    return this.find({ _id });
-}
-
-// 게시글 id를 통해 업데이트
-postSchema.statics.updateByPostid = function (_id, payload) {
-    return this.findOneAndUpdate({ _id }, payload, { new: true });
-}
-
-// 게시글 id를 통해 삭제
-postSchema.statics.deleteByPostid = function (_id) {
-    return this.remove({ _id });
-}
 
 module.exports = mongoose.model('Post', postSchema);

--- a/backend/package.json
+++ b/backend/package.json
@@ -15,6 +15,7 @@
     "express-mysql-session": "^2.1.4",
     "express-session": "^1.17.1",
     "http-errors": "~1.6.3",
+    "mongoose": "^5.10.5",
     "morgan": "~1.9.1",
     "multer": "^1.4.2",
     "mysql": "^2.18.1",

--- a/backend/routes/article.js
+++ b/backend/routes/article.js
@@ -1,6 +1,8 @@
 var express = require("express");
 var router = express.Router();
 
+var Post = require('../models/post');
+
 // mysql 선언
 var dbConObj = require("../lib/db_config");
 var conn = dbConObj.init();
@@ -19,7 +21,19 @@ router.get("/get/:articleID", function (req, res, next) {
     'SELECT p.post_id, p.board_id, p.ca_id, p.user_idx, u.name, p.contents, p.title, p.hit, date_format(p.write_date, "%y-%m-%d %a %T") as write_date FROM post p, capdi_users u WHERE p.post_id = ? AND p.user_idx = u.user_idx',
     [articleID],
     function (err, row) {
-      res.send(row);
+      if (row != null) {
+        // MongoDB에서 본문 부분만 읽어들여 row에 추가한다
+        Post.findOne({post_id: row[0].post_id}, (err, result) => {
+          // 아직 MongoDB에 등록되지 않은(MySQL시절) 게시글이라면
+          // 읽어온 MySQL게시글로 MongoDB 데이터를 생성 후, 구 MySQL 게시글을 반환한다
+          if (result === null) {
+            Post.create({post_id: row[0].post_id, contents: row[0].contents})
+            return res.send(row);
+          }
+          row[0].contents = result.contents;
+          res.send(row);
+        });
+      }
     }
   );
 });

--- a/backend/routes/post.js
+++ b/backend/routes/post.js
@@ -2,6 +2,9 @@ const express = require("express");
 const router = express.Router();
 const tfScript = require("./../lib/TFScripts/tfFunction");
 
+// MongoDB Post Model
+const Post = require("../models/post");
+
 // mysql 선언
 const dbConObj = require("../lib/db_config");
 const conn = dbConObj.init();
@@ -66,6 +69,14 @@ router.get("/categoryName/:categoryId", function (req, res) {
 //글쓰기
 router.post("/insertPost", function (req, res) {
   const post = req.body.posting;
+
+  Post.create({
+    title: post.title,
+    content: post.contents,
+  }, (error) => {
+    console.log(error);
+  });
+  
 
   // TODO: Convert in NoSQL
   conn.query(

--- a/frontend/src/components/Post/PostBody.vue
+++ b/frontend/src/components/Post/PostBody.vue
@@ -34,16 +34,7 @@
 								<div>
 									<label class="col-form-label-lg">본문</label>
 									<!-- Toast UI Editor -->
-									<editor ref="toastuiEditor" :height="800" :options="editorOptions" />
-									<!-- <textarea
-										type="text"
-										class="form-control"
-										cols="500"
-										rows="20"
-										v-model="contentArea"
-										id="contentArea"
-									></textarea
-									><br /> -->
+									<editor ref="toastuiEditor" :height="800" :options="editorOptions" initialEditType="wysiwyg" />
 								</div>
 							</div>
 						</div>
@@ -112,8 +103,8 @@
 			</div>
 
 			<div style="margin-bottom: 30px" class="file_upload">
-				<!-- <input type="file" id="file" ref="file" name="file" v-on:change="handleFileUpload()" /> -->
-				<!-- <button v-on:click="submitFile()">확인</button> -->
+				<input type="file" id="file" ref="file" name="file" v-on:change="handleFileUpload()" />
+				<button v-on:click="submitFile()">확인</button>
 			</div>
 
 			<div id="buttonFunction">
@@ -179,6 +170,7 @@ export default {
 			sessionName: this.$session.get('name'),
 			editorOptions: {
 				language: 'ko-KR',
+				hideModeSwitch: true,
 			},
 		};
 	},

--- a/frontend/src/components/Post/PostBody.vue
+++ b/frontend/src/components/Post/PostBody.vue
@@ -34,7 +34,14 @@
 								<div>
 									<label class="col-form-label-lg">본문</label>
 									<!-- Toast UI Editor -->
-									<editor ref="toastuiEditor" :height="800" :options="editorOptions" initialEditType="wysiwyg" />
+									<editor
+										ref="toastuiEditor"
+										v-if="contentArea != ''"
+										:initialValue="contentArea"
+										:height="800"
+										:options="editorOptions"
+										initialEditType="wysiwyg"
+									/>
 								</div>
 							</div>
 						</div>
@@ -264,7 +271,7 @@ export default {
 			//유효성 검사 후 전송
 			if (this.titleText === '') {
 				alert('제목을 입력하세요.');
-			} else if (this.contentArea === '') {
+			} else if (this.$refs.toastuiEditor.invoke('getMarkdown') === '') {
 				alert('본문을 입력하세요.');
 			} else if (this.checkedNames === '') {
 				alert('카테고리를 선택하세요.');
@@ -277,7 +284,7 @@ export default {
 								board_id: 1,
 								ca_id: this.categoryId,
 								user_idx: this.sessionIdx,
-								contents: this.contentArea,
+								contents: this.$refs.toastuiEditor.invoke('getMarkdown'),
 								title: this.titleText,
 								update_date: submitdate,
 							},


### PR DESCRIPTION
MySQL과 MongoDB를 혼용해서 게시글 저장하게끔 구현했습니다
MySQL에는 게시글의 기초데이터들을 저장하며, MongoDB에서는 해당 게시글의 본문 부분만을 저장하게끔 우선 구현했습니다.

현재 CRUD 모두 구현 완료하였습니다.

추가로, Toast 에디터 작성시 WYSIWYG으로 고정사용 하게끔 변환했습니다.

backend npn install 후, backend/libs/mongo_config.js 파일 추가 후 정상 동작 합니다.

[Plus MongoDB.pdf](https://github.com/och5351/plus-web-project/files/5229681/Plus.MongoDB.pdf)
