### PR TITLE
Backend Server BodyParser Resize

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -23,7 +23,9 @@ app.set("views", path.join(__dirname, "views"));
 app.set("view engine", "pug");
 
 app.use(logger("dev"));
-app.use(express.json());
+app.use(express.json({
+    limit: '50mb'
+}));
 app.use(express.urlencoded({ extended: false }));
 app.use(cookieParser());
 app.use(express.static(path.join(__dirname, "public")));


### PR DESCRIPTION
바디파서 용량문제로 게시글 업로드가 안되는 부분 해결
50MB로 현재 증량해놓음, 검토 후 재 조정 필요